### PR TITLE
Corrige fórmula de juros

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -20,7 +20,7 @@ namespace juros
             Console.WriteLine("Tempo (meses):");
             double t = Convert.ToDouble(Console.ReadLine());
 
-            double j = c * t * i;
+            double j = c * (i/100) * t;
             double m = c + j;
 
             Console.WriteLine();


### PR DESCRIPTION
Dois por cento = 2 / 100
Sendo assim, temos que dividir o juro digitado pelo usuário por 100 ou multiplicar por 0,01